### PR TITLE
feat: added cli command to send usd or sats explicitly

### DIFF
--- a/src/client/graphql/mutations/intraledger_usd_send.graphql
+++ b/src/client/graphql/mutations/intraledger_usd_send.graphql
@@ -1,0 +1,9 @@
+  mutation IntraLedgerUsdPaymentSend($input: IntraLedgerUsdPaymentSendInput!) {
+    intraLedgerUsdPaymentSend(input: $input) {
+      errors {
+        __typename
+        message
+      }
+      status
+    }
+  }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -207,6 +207,51 @@ impl GaloyClient {
         }
     }
 
+    pub fn intraleger_usd_send(
+        &self,
+        username: String,
+        amount: Decimal,
+        memo: Option<String>,
+    ) -> anyhow::Result<UsdPaymentSendResult> {
+        let me = self.me()?;
+        let wallet_id = me.default_account.default_wallet_id;
+
+        let recipient_wallet_id = self.default_wallet(username)?;
+        let input = IntraLedgerUsdPaymentSendInput {
+            amount,
+            memo,
+            recipient_wallet_id,
+            wallet_id,
+        };
+
+        let variables = intra_ledger_usd_payment_send::Variables { input };
+
+        let response_body = post_graphql::<IntraLedgerUsdPaymentSend, _>(
+            &self.graphql_client,
+            &self.api,
+            variables,
+        )
+        .context("issue fetching response")?;
+
+        let response_data = response_body.data.context("Query failed or is empty")?; // TODO: understand when this can fail here
+
+        if !response_data
+            .intra_ledger_usd_payment_send
+            .errors
+            .is_empty()
+        {
+            bail!(format!(
+                "payment error: {:?}",
+                response_data.intra_ledger_usd_payment_send.errors
+            ))
+        };
+
+        match response_data.intra_ledger_usd_payment_send.status {
+            Some(status) => Ok(status),
+            None => bail!("failed payment (empty response)"),
+        }
+    }
+
     // TODO: check if we can do self without &
     pub fn batch(self, filename: String, price: Decimal) -> anyhow::Result<()> {
         let mut batch = Batch::new(self, price);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,6 +15,8 @@ pub use error::*;
 pub mod batch;
 pub use batch::Batch;
 
+use self::query_me::WalletCurrency;
+
 pub mod server;
 
 pub struct GaloyClient {
@@ -176,14 +178,21 @@ impl GaloyClient {
         memo: Option<String>,
     ) -> anyhow::Result<PaymentSendResult> {
         let me = self.me()?;
-        let wallet_id = me.default_account.default_wallet_id;
+        let btc_wallet_id = me
+            .default_account
+            .wallets
+            .iter()
+            .find(|wallet| wallet.wallet_currency == WalletCurrency::BTC)
+            .map(|wallet| &wallet.id)
+            .expect("Can't get BTC wallet")
+            .to_owned();
 
         let recipient_wallet_id = self.default_wallet(username)?;
         let input = IntraLedgerPaymentSendInput {
             amount,
             memo,
             recipient_wallet_id,
-            wallet_id,
+            wallet_id: btc_wallet_id,
         };
 
         let variables = intra_ledger_payment_send::Variables { input };
@@ -214,14 +223,21 @@ impl GaloyClient {
         memo: Option<String>,
     ) -> anyhow::Result<UsdPaymentSendResult> {
         let me = self.me()?;
-        let wallet_id = me.default_account.default_wallet_id;
+        let usd_wallet_id = me
+            .default_account
+            .wallets
+            .iter()
+            .find(|wallet| wallet.wallet_currency == WalletCurrency::USD)
+            .map(|wallet| &wallet.id)
+            .expect("Can't get USD wallet")
+            .to_owned();
 
         let recipient_wallet_id = self.default_wallet(username)?;
         let input = IntraLedgerUsdPaymentSendInput {
             amount,
             memo,
             recipient_wallet_id,
-            wallet_id,
+            wallet_id: usd_wallet_id,
         };
 
         let variables = intra_ledger_usd_payment_send::Variables { input };

--- a/src/client/queries.rs
+++ b/src/client/queries.rs
@@ -39,7 +39,7 @@ pub use self::query_globals::QueryGlobalsGlobals;
 #[graphql(
     schema_path = "src/client/graphql/schema.graphql",
     query_path = "src/client/graphql/queries/me.graphql",
-    response_derives = "Debug, Serialize"
+    response_derives = "Debug, Serialize, PartialEq"
 )]
 pub(super) struct QueryMe;
 pub use self::query_me::QueryMeMe;

--- a/src/client/queries.rs
+++ b/src/client/queries.rs
@@ -5,6 +5,7 @@ use rust_decimal::Decimal;
 type Username = String;
 type WalletId = String;
 type SatAmount = Decimal;
+type CentAmount = Decimal;
 type Memo = String;
 type Phone = String;
 type AuthToken = String;
@@ -54,6 +55,16 @@ pub use self::query_me::QueryMeMe;
 pub(super) struct IntraLedgerPaymentSend;
 pub use self::intra_ledger_payment_send::IntraLedgerPaymentSendInput;
 pub use self::intra_ledger_payment_send::PaymentSendResult;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/client/graphql/schema.graphql",
+    query_path = "src/client/graphql/mutations/intraledger_usd_send.graphql",
+    response_derives = "Debug, Serialize"
+)]
+pub(super) struct IntraLedgerUsdPaymentSend;
+pub use self::intra_ledger_usd_payment_send::IntraLedgerUsdPaymentSendInput;
+pub use self::intra_ledger_usd_payment_send::PaymentSendResult as UsdPaymentSendResult;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,8 @@ enum Commands {
 
 #[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
 enum Wallet {
-    BTC,
-    USD,
+    Btc,
+    Usd,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -127,22 +127,22 @@ fn main() -> anyhow::Result<()> {
             sats,
             memo,
         } => {
-            if (wallet == Wallet::BTC && sats.is_none())
-                || (wallet == Wallet::USD && cents.is_none())
+            if (wallet == Wallet::Btc && sats.is_none())
+                || (wallet == Wallet::Usd && cents.is_none())
             {
                 eprintln!("Appropriate amount (sats/cents) not provided");
                 std::process::exit(1);
             }
 
             match wallet {
-                Wallet::BTC => {
+                Wallet::Btc => {
                     let sats = sats.expect("Can't unwrap sats");
                     let result = galoy_cli
                         .intraleger_send(username, sats, memo)
                         .context("issue sending intraledger")?;
                     println!("{:?}", result);
                 }
-                Wallet::USD => {
+                Wallet::Usd => {
                     let cents = cents.expect("Can't unwrap cents");
                     let result = galoy_cli
                         .intraleger_usd_send(username, cents, memo)


### PR DESCRIPTION
Allows for things like:

```bash
galoy-cli pay --username test --wallet btc --sats 50
galoy-cli pay --username test --wallet usd --cents 25
```

- Adds intraLedgerUsdPaymentSend