### PR TITLE
Improve Wallet-Specific Error Messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,10 +127,13 @@ fn main() -> anyhow::Result<()> {
             sats,
             memo,
         } => {
-            if (wallet == Wallet::Btc && sats.is_none())
-                || (wallet == Wallet::Usd && cents.is_none())
-            {
-                eprintln!("Appropriate amount (sats/cents) not provided");
+            if wallet == Wallet::Btc && sats.is_none() {
+                eprintln!("For btc wallet, use --sats to specify amount");
+                std::process::exit(1);
+            }
+
+            if wallet == Wallet::Usd && cents.is_none() {
+                eprintln!("For usd wallet, use --cents to specify amount");
                 std::process::exit(1);
             }
 


### PR DESCRIPTION
This PR addresses an issue where the error messages weren't specific enough when users chose inconsistent wallet and currency arguments.

**Before**:
- Error: `Appropriate amount (sats/cents) not provided.`

**After**:
- BTC Error: `For btc wallet, use --sats.`
- USD Error: `For usd wallet, use --cents.`

