### PR TITLE
feat: Implement 'balance' command to fetch wallet balance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@
 mod client;
 
 pub use client::*;
+
+pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,13 @@ enum Commands {
     },
     /// Execute Me query
     Me,
+    /// Fetch the balance of a wallet
+    Balance {
+        #[clap(long)]
+        btc: bool,
+        #[clap(long)]
+        usd: bool,
+    },
     /// Execute a Payment
     Pay {
         #[clap(short, long)]
@@ -123,6 +130,18 @@ fn main() -> anyhow::Result<()> {
                 "{}",
                 serde_json::to_string_pretty(&result).expect("Can't serialize json")
             );
+        }
+        Commands::Balance { btc, usd } => {
+            let wallet_type = match (btc, usd) {
+                (true, true) | (false, false) => None,
+                (true, false) => Some(Wallet::Btc),
+                (false, true) => Some(Wallet::Usd),
+            };
+
+            let balance = galoy_cli
+                .fetch_balance(wallet_type)
+                .context("can't fetch balance")?;
+            println!("{}", balance);
         }
         Commands::Pay {
             username,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ use std::fs::{self};
 mod constants;
 mod token;
 
+use galoy_cli::types::*;
+
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
@@ -80,12 +82,6 @@ enum Commands {
     },
     /// execute a batch payment
     Batch { filename: String, price: Decimal },
-}
-
-#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
-enum Wallet {
-    Btc,
-    Usd,
 }
 
 fn main() -> anyhow::Result<()> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, clap::ValueEnum, PartialEq, Eq)]
+pub enum Wallet {
+    Btc,
+    Usd,
+}


### PR DESCRIPTION
This Pull Request introduces a new command, `balance`, to the CLI. The `balance` command is used to fetch the user's balance from their wallet.

Users can fetch their balance in four different ways:

- `balance --usd`: Fetches the balance in the USD wallet.
- `balance --btc`: Fetches the balance in the BTC wallet.
- `balance` or `balance --usd --btc`: Fetches the balance from both the wallets and specifies the default one.

In the process of making these changes, the hardcoded `Wallet` type in `main.rs` has been moved to a new file, `types.rs`, which is now being exported from `lib.rs`. This centralizes the handling of types and makes the code more scalable for future expansions.

**Issue:** #145 