### PR TITLE
feat: List Transactions

### DIFF
--- a/src/app/operations/user.rs
+++ b/src/app/operations/user.rs
@@ -18,6 +18,25 @@ impl App {
         Ok(())
     }
 
+    pub async fn list_transactions(
+        &self,
+        after: Option<String>,
+        before: Option<String>,
+        last: Option<i64>,
+        first: Option<i64>,
+        wallet_ids: Option<Vec<Option<String>>>,
+    ) -> anyhow::Result<()> {
+        let result = self
+            .client
+            .list_transactions(after, before, last, first, wallet_ids)
+            .await
+            .context("Error occurred while fetching transactions")?;
+
+        println!("{:?}", result);
+
+        Ok(())
+    }
+
     pub async fn set_username(&self, username: String) -> anyhow::Result<()> {
         self.client
             .set_username(username)

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -32,6 +32,19 @@ pub enum Command {
     Logout,
     /// Execute Me query
     Me,
+    // Lists all transactions of user
+    Transactions {
+        #[clap(short, long)]
+        after: Option<String>,
+        #[clap(short, long)]
+        before: Option<String>,
+        #[clap(short, long)]
+        last: Option<i64>,
+        #[clap(short, long)]
+        first: Option<i64>,
+        #[clap(long, use_value_delimiter = true)]
+        wallet_ids: Option<Vec<Option<String>>>,
+    },
     /// Get WalletId for an account
     DefaultWallet {
         #[clap(value_parser)]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -34,16 +34,16 @@ pub enum Command {
     Me,
     // Lists all transactions of user
     Transactions {
-        #[clap(short, long)]
-        after: Option<String>,
-        #[clap(short, long)]
-        before: Option<String>,
-        #[clap(short, long)]
+        // #[clap(short, long)]
+        // after: Option<String>,
+        // #[clap(short, long)]
+        // before: Option<String>,
+        #[clap(short, long, conflicts_with("first"))]
         last: Option<i64>,
         #[clap(short, long)]
         first: Option<i64>,
-        #[clap(long, use_value_delimiter = true)]
-        wallet_ids: Option<Vec<Option<String>>>,
+        // #[clap(long, use_value_delimiter = true)]
+        // wallet_ids: Option<Vec<Option<String>>>,
     },
     /// Get WalletId for an account
     DefaultWallet {

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -21,14 +21,13 @@ pub async fn run() -> anyhow::Result<()> {
             app.me().await?;
         }
         Command::Transactions {
-            after,
-            before,
+            // after,
+            // before,
             last,
             first,
-            wallet_ids,
+            // wallet_ids,
         } => {
-            app.list_transactions(after, before, last, first, wallet_ids)
-                .await?;
+            app.list_transactions(last, first).await?;
         }
         Command::DefaultWallet { username } => {
             app.default_wallet(username).await?;

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -20,6 +20,16 @@ pub async fn run() -> anyhow::Result<()> {
         Command::Me => {
             app.me().await?;
         }
+        Command::Transactions {
+            after,
+            before,
+            last,
+            first,
+            wallet_ids,
+        } => {
+            app.list_transactions(after, before, last, first, wallet_ids)
+                .await?;
+        }
         Command::DefaultWallet { username } => {
             app.default_wallet(username).await?;
         }

--- a/src/client/errors/me_error.rs
+++ b/src/client/errors/me_error.rs
@@ -4,4 +4,6 @@ use thiserror::Error;
 pub enum MeError {
     #[error("Failed to unwrap .me")]
     FailedToUnwrapMe,
+    #[error("Failed to unwrap transactions")]
+    FailedToUnwrapTransactions,
 }

--- a/src/client/gql/queries/transactions.gql
+++ b/src/client/gql/queries/transactions.gql
@@ -1,8 +1,8 @@
-query Transactions($after: String, $before: String, $first: Int, $last: Int, $walletIds: [WalletId]) {
+query Transactions {
   me {
     defaultAccount {
       __typename
-      transactions(after: $after, before: $before, first: $first, last: $last, walletIds: $walletIds) {
+      transactions {
         edges {
           cursor
           node {

--- a/src/client/gql/queries/transactions.gql
+++ b/src/client/gql/queries/transactions.gql
@@ -1,0 +1,59 @@
+query Transactions($after: String, $before: String, $first: Int, $last: Int, $walletIds: [WalletId]) {
+  me {
+    defaultAccount {
+      __typename
+      transactions(after: $after, before: $before, first: $first, last: $last, walletIds: $walletIds) {
+        edges {
+          cursor
+          node {
+            createdAt
+            direction
+            id
+            initiationVia {
+              __typename
+              ... on InitiationViaIntraLedger {
+                counterPartyUsername
+                counterPartyWalletId
+              }
+              ... on InitiationViaLn {
+                paymentHash
+              }
+              ... on InitiationViaOnChain {
+                address
+              }
+            }
+            memo
+            settlementAmount
+            settlementCurrency
+            settlementDisplayAmount
+            settlementDisplayCurrency
+            settlementDisplayFee
+            settlementFee
+            settlementPrice {
+              base
+              currencyUnit
+              formattedAmount
+              offset
+            }
+            settlementVia {
+              __typename
+              ... on SettlementViaIntraLedger {
+                counterPartyUsername
+                counterPartyWalletId
+              }
+              ... on SettlementViaLn {
+                preImage
+                paymentSecret
+              }
+              ... on SettlementViaOnChain {
+                transactionHash
+                vout
+              }
+            }
+            status
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/client/gql/schema.gql
+++ b/src/client/gql/schema.gql
@@ -1,871 +1,142 @@
-type GraphQLApplicationError implements Error {
-  message: String!
-  path: [String]
-  code: String
-}
-
-interface Error {
-  message: String!
-  path: [String]
-  code: String
-}
-
-type ConsumerAccount implements Account {
-  id: ID!
-  wallets: [Wallet!]!
-  defaultWalletId: WalletId!
-  displayCurrency: DisplayCurrency!
-  level: AccountLevel!
-  realtimePrice: RealtimePrice!
-
-  # return CSV stream, base64 encoded, of the list of transactions in the wallet
-  csvTransactions(walletIds: [WalletId!]!): String!
-  limits: AccountLimits!
-
-  # List the quiz questions of the consumer account
-  quiz: [Quiz!]!
-
-  # A list of all transactions associated with walletIds optionally passed.
-  transactions(
-    # Returns the items in the list that come after the specified cursor.
-    after: String
-
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
-    before: String
-
-    # Returns the last n items from the list.
-    last: Int
-    walletIds: [WalletId]
-  ): TransactionConnection
-}
-
 interface Account {
-  id: ID!
-  wallets: [Wallet!]!
+  csvTransactions(walletIds: [WalletId!]!): String!
   defaultWalletId: WalletId!
   displayCurrency: DisplayCurrency!
+  id: ID!
   level: AccountLevel!
-  realtimePrice: RealtimePrice!
-  csvTransactions(walletIds: [WalletId!]!): String!
   limits: AccountLimits!
+  realtimePrice: RealtimePrice!
   transactions(
-    # Returns the items in the list that come after the specified cursor.
+    """Returns the items in the list that come after the specified cursor."""
     after: String
 
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
+    """Returns the items in the list that come before the specified cursor."""
     before: String
 
-    # Returns the last n items from the list.
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
     last: Int
     walletIds: [WalletId]
   ): TransactionConnection
+  wallets: [Wallet!]!
 }
 
-# A generic wallet which stores value in one of our supported currencies.
-interface Wallet {
-  id: ID!
-  accountId: ID!
-  walletCurrency: WalletCurrency!
-  balance: SignedAmount!
-  pendingIncomingBalance: SignedAmount!
-
-  # Transactions are ordered anti-chronologically,
-  # ie: the newest transaction will be first
-  transactions(
-    # Returns the items in the list that come after the specified cursor.
-    after: String
-
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
-    before: String
-
-    # Returns the last n items from the list.
-    last: Int
-  ): TransactionConnection
-
-  # Transactions are ordered anti-chronologically,
-  # ie: the newest transaction will be first
-  transactionsByAddress(
-    # Returns the items in the list that come after the specified cursor.
-    after: String
-
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
-    before: String
-
-    # Returns the last n items from the list.
-    last: Int
-
-    # Returns the items that include this address.
-    address: OnChainAddress!
-  ): TransactionConnection
+type AccountDeletePayload {
+  errors: [Error!]!
+  success: Boolean!
 }
-
-enum WalletCurrency {
-  BTC
-  USD
-}
-
-# An amount (of a currency) that can be negative (e.g. in a transaction)
-scalar SignedAmount
-
-# A connection to a list of items.
-type TransactionConnection {
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-
-  # A list of edges.
-  edges: [TransactionEdge!]
-}
-
-# Information about pagination in a connection.
-type PageInfo {
-  # When paginating forwards, are there more items?
-  hasNextPage: Boolean!
-
-  # When paginating backwards, are there more items?
-  hasPreviousPage: Boolean!
-
-  # When paginating backwards, the cursor to continue.
-  startCursor: String
-
-  # When paginating forwards, the cursor to continue.
-  endCursor: String
-}
-
-# An edge in a connection.
-type TransactionEdge {
-  # The item at the end of the edge
-  node: Transaction!
-
-  # A cursor for use in pagination
-  cursor: String!
-}
-
-# Give details about an individual transaction.
-# Galoy have a smart routing system which is automatically
-# settling intraledger when both the payer and payee use the same wallet
-# therefore it's possible the transactions is being initiated onchain
-# or with lightning but settled intraledger.
-type Transaction {
-  id: ID!
-
-  # From which protocol the payment has been initiated.
-  initiationVia: InitiationVia!
-
-  # To which protocol the payment has settled on.
-  settlementVia: SettlementVia!
-
-  # Amount of the settlement currency sent or received.
-  settlementAmount: SignedAmount!
-  settlementFee: SignedAmount!
-
-  # Price in WALLETCURRENCY/SETTLEMENTUNIT at time of settlement.
-  settlementPrice: PriceOfOneSettlementMinorUnitInDisplayMinorUnit!
-
-  # Wallet currency for transaction.
-  settlementCurrency: WalletCurrency!
-  settlementDisplayAmount: SignedDisplayMajorAmount!
-  settlementDisplayFee: SignedDisplayMajorAmount!
-  settlementDisplayCurrency: DisplayCurrency!
-  direction: TxDirection!
-  status: TxStatus!
-  memo: Memo
-  createdAt: Timestamp!
-}
-
-union InitiationVia =
-    InitiationViaIntraLedger
-  | InitiationViaLn
-  | InitiationViaOnChain
-
-type InitiationViaIntraLedger {
-  counterPartyWalletId: WalletId
-  counterPartyUsername: Username
-}
-
-# Unique identifier of a wallet
-scalar WalletId
-
-# Unique identifier of a user
-scalar Username
-
-type InitiationViaLn {
-  paymentHash: PaymentHash!
-}
-
-scalar PaymentHash
-
-type InitiationViaOnChain {
-  address: OnChainAddress!
-}
-
-# An address for an on-chain bitcoin destination
-scalar OnChainAddress
-
-union SettlementVia =
-    SettlementViaIntraLedger
-  | SettlementViaLn
-  | SettlementViaOnChain
-
-type SettlementViaIntraLedger {
-  counterPartyWalletId: WalletId
-
-  # Settlement destination: Could be null if the payee does not have a username
-  counterPartyUsername: Username
-}
-
-type SettlementViaLn {
-  paymentSecret: LnPaymentSecret
-    @deprecated(
-      reason: "Shifting property to 'preImage' to improve granularity of the LnPaymentSecret type"
-    )
-  preImage: LnPaymentPreImage
-}
-
-scalar LnPaymentSecret
-
-scalar LnPaymentPreImage
-
-type SettlementViaOnChain {
-  transactionHash: OnChainTxHash
-  vout: Int
-}
-
-scalar OnChainTxHash
-
-# Price of 1 sat or 1 usd cent in base/offset. To calculate, use: `base / 10^offset`
-type PriceOfOneSettlementMinorUnitInDisplayMinorUnit implements PriceInterface {
-  base: SafeInt!
-  offset: Int!
-  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
-  formattedAmount: String!
-    @deprecated(reason: "Deprecated please use `base / 10^offset`")
-}
-
-interface PriceInterface {
-  base: SafeInt!
-  offset: Int!
-  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
-}
-
-# Non-fractional signed whole numeric value between -(2^53) + 1 and 2^53 - 1
-scalar SafeInt
-
-# A string amount (of a currency) that can be negative (e.g. in a transaction)
-scalar SignedDisplayMajorAmount
-
-# Display currency of an account
-scalar DisplayCurrency
-
-enum TxDirection {
-  SEND
-  RECEIVE
-}
-
-enum TxStatus {
-  PENDING
-  SUCCESS
-  FAILURE
-}
-
-# Text field in a lightning payment transaction
-scalar Memo
-
-# Timestamp field, serialized as Unix time (the number of seconds since the Unix epoch)
-scalar Timestamp
 
 enum AccountLevel {
-  ZERO
   ONE
   TWO
-}
-
-type RealtimePrice {
-  id: ID!
-
-  # Unix timestamp (number of seconds elapsed since January 1, 1970 00:00:00 UTC)
-  timestamp: Timestamp!
-  denominatorCurrency: DisplayCurrency!
-  btcSatPrice: PriceOfOneSatInMinorUnit!
-  usdCentPrice: PriceOfOneUsdCentInMinorUnit!
-}
-
-# Price of 1 sat in base/offset. To calculate, use: `base / 10^offset`
-type PriceOfOneSatInMinorUnit implements PriceInterface {
-  base: SafeInt!
-  offset: Int!
-  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
-}
-
-# Price of 1 usd cent in base/offset. To calculate, use: `base / 10^offset`
-type PriceOfOneUsdCentInMinorUnit implements PriceInterface {
-  base: SafeInt!
-  offset: Int!
-  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
-}
-
-type AccountLimits {
-  # Limits for withdrawing to external onchain or lightning destinations.
-  withdrawal: [AccountLimit!]!
-
-  # Limits for sending to other internal accounts.
-  internalSend: [AccountLimit!]!
-
-  # Limits for converting between currencies among a account's own wallets.
-  convert: [AccountLimit!]!
+  ZERO
 }
 
 interface AccountLimit {
-  # The current maximum limit for a given 24 hour period.
-  totalLimit: CentAmount!
+  """The rolling time interval in seconds that the limits would apply for."""
+  interval: Seconds
 
-  # The amount of cents remaining below the limit for the current 24 hour period.
+  """
+  The amount of cents remaining below the limit for the current 24 hour period.
+  """
   remainingLimit: CentAmount
 
-  # The rolling time interval in seconds that the limits would apply for.
-  interval: Seconds
+  """The current maximum limit for a given 24 hour period."""
+  totalLimit: CentAmount!
 }
 
-# (Positive) Cent amount (1/100 of a dollar)
-scalar CentAmount
+type AccountLimits {
+  """
+  Limits for converting between currencies among a account's own wallets.
+  """
+  convert: [AccountLimit!]!
 
-# (Positive) amount of seconds
-scalar Seconds
+  """Limits for sending to other internal accounts."""
+  internalSend: [AccountLimit!]!
 
-type Quiz {
-  id: ID!
-
-  # The reward in Satoshis for the quiz question
-  amount: SatAmount!
-  completed: Boolean!
+  """Limits for withdrawing to external onchain or lightning destinations."""
+  withdrawal: [AccountLimit!]!
 }
 
-# (Positive) Satoshi amount
-scalar SatAmount
+input AccountUpdateDefaultWalletIdInput {
+  walletId: WalletId!
+}
 
-# A wallet belonging to an account which contains a BTC balance and a list of transactions.
+type AccountUpdateDefaultWalletIdPayload {
+  account: ConsumerAccount
+  errors: [Error!]!
+}
+
+input AccountUpdateDisplayCurrencyInput {
+  currency: DisplayCurrency!
+}
+
+type AccountUpdateDisplayCurrencyPayload {
+  account: ConsumerAccount
+  errors: [Error!]!
+}
+
+"""An Opaque Bearer token"""
+scalar AuthToken
+
+type AuthTokenPayload {
+  authToken: AuthToken
+  errors: [Error!]!
+  totpRequired: Boolean
+}
+
+"""
+A wallet belonging to an account which contains a BTC balance and a list of transactions.
+"""
 type BTCWallet implements Wallet {
-  id: ID!
   accountId: ID!
-  walletCurrency: WalletCurrency!
 
-  # A balance stored in BTC.
+  """A balance stored in BTC."""
   balance: SignedAmount!
+  id: ID!
 
-  # An unconfirmed incoming onchain balance.
+  """An unconfirmed incoming onchain balance."""
   pendingIncomingBalance: SignedAmount!
 
-  # A list of BTC transactions associated with this wallet.
+  """A list of BTC transactions associated with this wallet."""
   transactions(
-    # Returns the items in the list that come after the specified cursor.
+    """Returns the items in the list that come after the specified cursor."""
     after: String
 
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
+    """Returns the items in the list that come before the specified cursor."""
     before: String
 
-    # Returns the last n items from the list.
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
     last: Int
   ): TransactionConnection
   transactionsByAddress(
-    # Returns the items in the list that come after the specified cursor.
+    """Returns the items that include this address."""
+    address: OnChainAddress!
+
+    """Returns the items in the list that come after the specified cursor."""
     after: String
 
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
+    """Returns the items in the list that come before the specified cursor."""
     before: String
 
-    # Returns the last n items from the list.
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
     last: Int
-
-    # Returns the items that include this address.
-    address: OnChainAddress!
   ): TransactionConnection
-}
-
-# A wallet belonging to an account which contains a USD balance and a list of transactions.
-type UsdWallet implements Wallet {
-  id: ID!
-  accountId: ID!
   walletCurrency: WalletCurrency!
-  balance: SignedAmount!
-
-  # An unconfirmed incoming onchain balance.
-  pendingIncomingBalance: SignedAmount!
-  transactions(
-    # Returns the items in the list that come after the specified cursor.
-    after: String
-
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
-    before: String
-
-    # Returns the last n items from the list.
-    last: Int
-  ): TransactionConnection
-  transactionsByAddress(
-    # Returns the items in the list that come after the specified cursor.
-    after: String
-
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
-    before: String
-
-    # Returns the last n items from the list.
-    last: Int
-
-    # Returns the items that include this address.
-    address: OnChainAddress!
-  ): TransactionConnection
-}
-
-type OneDayAccountLimit implements AccountLimit {
-  # The current maximum limit for a given 24 hour period.
-  totalLimit: CentAmount!
-
-  # The amount of cents remaining below the limit for the current 24 hour period.
-  remainingLimit: CentAmount
-
-  # The rolling time interval value in seconds for the current 24 hour period.
-  interval: Seconds
-}
-
-type Query {
-  globals: Globals
-  usernameAvailable(username: Username!): Boolean
-  userDefaultWalletId(username: Username!): WalletId!
-    @deprecated(reason: "will be migrated to AccountDefaultWalletId")
-  accountDefaultWallet(
-    username: Username!
-    walletCurrency: WalletCurrency
-  ): PublicWallet!
-  businessMapMarkers: [MapMarker]
-  currencyList: [Currency!]!
-  mobileVersions: [MobileVersions]
-  quizQuestions: [QuizQuestion]
-    @deprecated(
-      reason: "TODO: remove. we don't need a non authenticated version of this query. the users can only do the query while authenticated"
-    )
-  btcPrice(currency: DisplayCurrency! = "USD"): Price
-    @deprecated(reason: "Deprecated in favor of realtimePrice")
-
-  # Returns 1 Sat and 1 Usd Cent price for the given currency
-  realtimePrice(currency: DisplayCurrency = "USD"): RealtimePrice!
-  btcPriceList(range: PriceGraphRange!): [PricePoint]
-  lnInvoicePaymentStatus(
-    input: LnInvoicePaymentStatusInput!
-  ): LnInvoicePaymentStatusPayload!
-  me: User
-  onChainTxFee(
-    walletId: WalletId!
-    address: OnChainAddress!
-    amount: SatAmount!
-    speed: PayoutSpeed = FAST
-  ): OnChainTxFee!
-  onChainUsdTxFee(
-    walletId: WalletId!
-    address: OnChainAddress!
-    amount: CentAmount!
-    speed: PayoutSpeed = FAST
-  ): OnChainUsdTxFee!
-  onChainUsdTxFeeAsBtcDenominated(
-    walletId: WalletId!
-    address: OnChainAddress!
-    amount: SatAmount!
-    speed: PayoutSpeed = FAST
-  ): OnChainUsdTxFee!
-}
-
-# Provides global settings for the application which might have an impact for the user.
-type Globals {
-  # A list of public keys for the running lightning nodes.
-  # This can be used to know if an invoice belongs to one of our nodes.
-  nodesIds: [String!]!
-
-  # Which network (mainnet, testnet, regtest, signet) this instance is running on.
-  network: Network!
-  buildInformation: BuildInformation!
-
-  # The domain name for lightning addresses accepted by this Galoy instance
-  lightningAddressDomain: String!
-
-  # A list of countries and their supported auth channels
-  supportedCountries: [Country!]!
-  lightningAddressDomainAliases: [String!]!
-}
-
-enum Network {
-  mainnet
-  testnet
-  signet
-  regtest
 }
 
 type BuildInformation {
-  commitHash: String
   buildTime: Timestamp
+  commitHash: String
   helmRevision: Int
-}
-
-type Country {
-  id: CountryCode!
-  supportedAuthChannels: [PhoneCodeChannelType!]!
-}
-
-# A CCA2 country code (ex US, FR, etc)
-scalar CountryCode
-
-enum PhoneCodeChannelType {
-  SMS
-  WHATSAPP
-}
-
-# A public view of a generic wallet which stores value in one of our supported currencies.
-type PublicWallet {
-  id: ID!
-  walletCurrency: WalletCurrency!
-}
-
-type MapMarker {
-  username: Username
-  mapInfo: MapInfo!
-}
-
-type MapInfo {
-  title: String!
-  coordinates: Coordinates!
-}
-
-type Coordinates {
-  longitude: Float!
-  latitude: Float!
-}
-
-type Currency {
-  id: ID!
-  symbol: String!
-  name: String!
-  flag: String!
-  fractionDigits: Int!
-}
-
-type MobileVersions {
-  platform: String!
-  currentSupported: Int!
-  minSupported: Int!
-}
-
-type QuizQuestion {
-  id: ID!
-
-  # The earn reward in Satoshis for the quiz question
-  earnAmount: SatAmount!
-}
-
-# Price amount expressed in base/offset. To calculate, use: `base / 10^offset`
-type Price {
-  base: SafeInt!
-  offset: Int!
-  currencyUnit: String!
-  formattedAmount: String!
-}
-
-type PricePoint {
-  # Unix timestamp (number of seconds elapsed since January 1, 1970 00:00:00 UTC)
-  timestamp: Timestamp!
-  price: Price!
-}
-
-# The range for the X axis in the BTC price graph
-enum PriceGraphRange {
-  ONE_DAY
-  ONE_WEEK
-  ONE_MONTH
-  ONE_YEAR
-  FIVE_YEARS
-}
-
-type LnInvoicePaymentStatusPayload {
-  errors: [Error!]!
-  status: InvoicePaymentStatus
-}
-
-enum InvoicePaymentStatus {
-  PENDING
-  PAID
-  EXPIRED
-}
-
-input LnInvoicePaymentStatusInput {
-  paymentRequest: LnPaymentRequest!
-}
-
-# BOLT11 lightning invoice payment request with the amount included
-scalar LnPaymentRequest
-
-type User {
-  id: ID!
-
-  # Phone number with international calling code.
-  phone: Phone
-
-  # Optional immutable user friendly identifier.
-  username: Username
-    @deprecated(reason: "will be moved to @Handle in Account and Wallet")
-
-  # Preferred language for user.
-  # When value is 'default' the intent is to use preferred language from OS settings.
-  language: Language!
-
-  # List the quiz questions the user may have completed.
-  quizQuestions: [UserQuizQuestion!]!
-    @deprecated(reason: "use Quiz from Account instead")
-
-  # Get full list of contacts.
-  # Can include the transactions associated with each contact.
-  contacts: [UserContact!]! @deprecated(reason: "will be moved to account")
-
-  # Get single contact details.
-  # Can include the transactions associated with the contact.
-  contactByUsername(username: Username!): UserContact!
-    @deprecated(reason: "will be moved to Accounts")
-  createdAt: Timestamp!
-  defaultAccount: Account!
-}
-
-# Phone number which includes country code
-scalar Phone
-
-scalar Language
-
-type UserQuizQuestion {
-  question: QuizQuestion!
-  completed: Boolean!
-}
-
-type UserContact {
-  id: Username!
-
-  # Actual identifier of the contact.
-  username: Username!
-
-  # Alias the user can set for this contact.
-  # Only the user can see the alias attached to their contact.
-  alias: ContactAlias
-  transactionsCount: Int!
-
-  # Paginated list of transactions sent to/from this contact.
-  transactions(
-    # Returns the items in the list that come after the specified cursor.
-    after: String
-
-    # Returns the first n items from the list.
-    first: Int
-
-    # Returns the items in the list that come before the specified cursor.
-    before: String
-
-    # Returns the last n items from the list.
-    last: Int
-  ): TransactionConnection
-}
-
-# An alias name that a user can set for a wallet (with which they have transactions)
-scalar ContactAlias
-
-type OnChainTxFee {
-  amount: SatAmount!
-  targetConfirmations: TargetConfirmations!
-    @deprecated(reason: "Ignored - will be removed")
-}
-
-# (Positive) Number of blocks in which the transaction is expected to be confirmed
-scalar TargetConfirmations
-
-enum PayoutSpeed {
-  FAST
-}
-
-type OnChainUsdTxFee {
-  amount: CentAmount!
-  targetConfirmations: TargetConfirmations!
-    @deprecated(reason: "Ignored - will be removed")
-}
-
-type Mutation {
-  userRequestAuthCode(input: UserRequestAuthCodeInput!): SuccessPayload!
-  userLogin(input: UserLoginInput!): AuthTokenPayload!
-  userLogout(input: UserLogoutInput!): AuthTokenPayload!
-  captchaCreateChallenge: CaptchaCreateChallengePayload!
-  captchaRequestAuthCode(input: CaptchaRequestAuthCodeInput!): SuccessPayload!
-
-  # Returns a lightning invoice for an associated wallet.
-  # When invoice is paid the value will be credited to a BTC wallet.
-  # Expires after 24 hours.
-  lnInvoiceCreateOnBehalfOfRecipient(
-    input: LnInvoiceCreateOnBehalfOfRecipientInput!
-  ): LnInvoicePayload!
-
-  # Returns a lightning invoice denominated in satoshis for an associated wallet.
-  # When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.
-  # Expires after 5 minutes (short expiry time because there is a USD/BTC exchange rate
-  #   associated with the amount).
-  lnUsdInvoiceCreateOnBehalfOfRecipient(
-    input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!
-  ): LnInvoicePayload!
-
-  # Returns a lightning invoice for an associated wallet.
-  # Can be used to receive any supported currency value (currently USD or BTC).
-  # Expires after 24 hours.
-  lnNoAmountInvoiceCreateOnBehalfOfRecipient(
-    input: LnNoAmountInvoiceCreateOnBehalfOfRecipientInput!
-  ): LnNoAmountInvoicePayload!
-  userLoginUpgrade(input: UserLoginUpgradeInput!): UpgradePayload!
-  userQuizQuestionUpdateCompleted(
-    input: UserQuizQuestionUpdateCompletedInput!
-  ): UserQuizQuestionUpdateCompletedPayload!
-    @deprecated(reason: "Use QuizCompletedMutation instead")
-  quizCompleted(input: QuizCompletedInput!): QuizCompletedPayload!
-  deviceNotificationTokenCreate(
-    input: DeviceNotificationTokenCreateInput!
-  ): SuccessPayload!
-  userUpdateLanguage(
-    input: UserUpdateLanguageInput!
-  ): UserUpdateLanguagePayload!
-  userUpdateUsername(
-    input: UserUpdateUsernameInput!
-  ): UserUpdateUsernamePayload!
-  userContactUpdateAlias(
-    input: UserContactUpdateAliasInput!
-  ): UserContactUpdateAliasPayload!
-    @deprecated(reason: "will be moved to AccountContact")
-  accountUpdateDefaultWalletId(
-    input: AccountUpdateDefaultWalletIdInput!
-  ): AccountUpdateDefaultWalletIdPayload!
-  accountUpdateDisplayCurrency(
-    input: AccountUpdateDisplayCurrencyInput!
-  ): AccountUpdateDisplayCurrencyPayload!
-  accountDelete: AccountDeletePayload!
-
-  # Actions a payment which is internal to the ledger e.g. it does
-  # not use onchain/lightning. Returns payment status (success,
-  # failed, pending, already_paid).
-  intraLedgerPaymentSend(
-    input: IntraLedgerPaymentSendInput!
-  ): PaymentSendPayload!
-
-  # Actions a payment which is internal to the ledger e.g. it does
-  # not use onchain/lightning. Returns payment status (success,
-  # failed, pending, already_paid).
-  intraLedgerUsdPaymentSend(
-    input: IntraLedgerUsdPaymentSendInput!
-  ): PaymentSendPayload!
-  lnInvoiceFeeProbe(input: LnInvoiceFeeProbeInput!): SatAmountPayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): SatAmountPayload!
-  lnNoAmountInvoiceFeeProbe(
-    input: LnNoAmountInvoiceFeeProbeInput!
-  ): SatAmountPayload!
-  lnNoAmountUsdInvoiceFeeProbe(
-    input: LnNoAmountUsdInvoiceFeeProbeInput!
-  ): CentAmountPayload!
-
-  # Returns a lightning invoice for an associated wallet.
-  # When invoice is paid the value will be credited to a BTC wallet.
-  # Expires after 24 hours.
-  lnInvoiceCreate(input: LnInvoiceCreateInput!): LnInvoicePayload!
-
-  # Returns a lightning invoice denominated in satoshis for an associated wallet.
-  # When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.
-  # Expires after 5 minutes (short expiry time because there is a USD/BTC exchange rate
-  # associated with the amount).
-  lnUsdInvoiceCreate(input: LnUsdInvoiceCreateInput!): LnInvoicePayload!
-
-  # Returns a lightning invoice for an associated wallet.
-  # Can be used to receive any supported currency value (currently USD or BTC).
-  # Expires after 24 hours.
-  lnNoAmountInvoiceCreate(
-    input: LnNoAmountInvoiceCreateInput!
-  ): LnNoAmountInvoicePayload!
-
-  # Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
-  # Provided wallet can be USD or BTC and must have sufficient balance to cover amount in lightning invoice.
-  # Returns payment status (success, failed, pending, already_paid).
-  lnInvoicePaymentSend(input: LnInvoicePaymentInput!): PaymentSendPayload!
-
-  # Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
-  # Provided wallet must be BTC and must have sufficient balance to cover amount specified in mutation request.
-  # Returns payment status (success, failed, pending, already_paid).
-  lnNoAmountInvoicePaymentSend(
-    input: LnNoAmountInvoicePaymentInput!
-  ): PaymentSendPayload!
-
-  # Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
-  # Provided wallet must be USD and have sufficient balance to cover amount specified in mutation request.
-  # Returns payment status (success, failed, pending, already_paid).
-  lnNoAmountUsdInvoicePaymentSend(
-    input: LnNoAmountUsdInvoicePaymentInput!
-  ): PaymentSendPayload!
-  onChainAddressCreate(
-    input: OnChainAddressCreateInput!
-  ): OnChainAddressPayload!
-  onChainAddressCurrent(
-    input: OnChainAddressCurrentInput!
-  ): OnChainAddressPayload!
-  onChainPaymentSend(input: OnChainPaymentSendInput!): PaymentSendPayload!
-  onChainUsdPaymentSend(input: OnChainUsdPaymentSendInput!): PaymentSendPayload!
-  onChainUsdPaymentSendAsBtcDenominated(
-    input: OnChainUsdPaymentSendAsBtcDenominatedInput!
-  ): PaymentSendPayload!
-  onChainPaymentSendAll(input: OnChainPaymentSendAllInput!): PaymentSendPayload!
-}
-
-type SuccessPayload {
-  errors: [Error!]!
-  success: Boolean
-}
-
-input UserRequestAuthCodeInput {
-  phone: Phone!
-  channel: PhoneCodeChannelType
-}
-
-type AuthTokenPayload {
-  errors: [Error!]!
-  authToken: AuthToken
-}
-
-# An Opaque Bearer token
-scalar AuthToken
-
-input UserLoginInput {
-  phone: Phone!
-  code: OneTimeAuthCode!
-}
-
-# An authentication code valid for a single use
-scalar OneTimeAuthCode
-
-input UserLogoutInput {
-  authToken: AuthToken!
 }
 
 type CaptchaCreateChallengePayload {
@@ -874,18 +145,272 @@ type CaptchaCreateChallengePayload {
 }
 
 type CaptchaCreateChallengeResult {
-  id: String!
   challengeCode: String!
-  newCaptcha: Boolean!
   failbackMode: Boolean!
+  id: String!
+  newCaptcha: Boolean!
 }
 
 input CaptchaRequestAuthCodeInput {
-  phone: Phone!
   challengeCode: String!
-  validationCode: String!
-  secCode: String!
   channel: PhoneCodeChannelType
+  phone: Phone!
+  secCode: String!
+  validationCode: String!
+}
+
+"""(Positive) Cent amount (1/100 of a dollar)"""
+scalar CentAmount
+
+type CentAmountPayload {
+  amount: CentAmount
+  errors: [Error!]!
+}
+
+type ConsumerAccount implements Account {
+  """
+  return CSV stream, base64 encoded, of the list of transactions in the wallet
+  """
+  csvTransactions(walletIds: [WalletId!]!): String!
+  defaultWalletId: WalletId!
+  displayCurrency: DisplayCurrency!
+  id: ID!
+  level: AccountLevel!
+  limits: AccountLimits!
+
+  """List the quiz questions of the consumer account"""
+  quiz: [Quiz!]!
+  realtimePrice: RealtimePrice!
+
+  """
+  A list of all transactions associated with walletIds optionally passed.
+  """
+  transactions(
+    """Returns the items in the list that come after the specified cursor."""
+    after: String
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String
+
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
+    last: Int
+    walletIds: [WalletId]
+  ): TransactionConnection
+  wallets: [Wallet!]!
+}
+
+"""
+An alias name that a user can set for a wallet (with which they have transactions)
+"""
+scalar ContactAlias
+
+type Coordinates {
+  latitude: Float!
+  longitude: Float!
+}
+
+type Country {
+  id: CountryCode!
+  supportedAuthChannels: [PhoneCodeChannelType!]!
+}
+
+"""A CCA2 country code (ex US, FR, etc)"""
+scalar CountryCode
+
+type Currency {
+  flag: String!
+  fractionDigits: Int!
+  id: ID!
+  name: String!
+  symbol: String!
+}
+
+type DepositFeesInformation {
+  minBankFee: String!
+
+  """below this amount minBankFee will be charged"""
+  minBankFeeThreshold: String!
+
+  """ratio to charge as basis points above minBankFeeThreshold amount"""
+  ratio: String!
+}
+
+input DeviceNotificationTokenCreateInput {
+  deviceToken: String!
+}
+
+"""Display currency of an account"""
+scalar DisplayCurrency
+
+type Email {
+  address: EmailAddress
+  verified: Boolean
+}
+
+"""Email address"""
+scalar EmailAddress
+
+"""
+An id to be passed between registrationInitiate and registrationValidate for confirming email
+"""
+scalar EmailRegistrationId
+
+interface Error {
+  code: String
+  message: String!
+  path: [String]
+}
+
+enum ExchangeCurrencyUnit {
+  BTCSAT
+  USDCENT
+}
+
+"""Feedback shared with our user"""
+scalar Feedback
+
+input FeedbackSubmitInput {
+  feedback: Feedback!
+}
+
+type FeesInformation {
+  deposit: DepositFeesInformation!
+}
+
+"""
+Provides global settings for the application which might have an impact for the user.
+"""
+type Globals {
+  buildInformation: BuildInformation!
+  feesInformation: FeesInformation!
+
+  """
+  The domain name for lightning addresses accepted by this Galoy instance
+  """
+  lightningAddressDomain: String!
+  lightningAddressDomainAliases: [String!]!
+
+  """
+  Which network (mainnet, testnet, regtest, signet) this instance is running on.
+  """
+  network: Network!
+
+  """
+  A list of public keys for the running lightning nodes.
+  This can be used to know if an invoice belongs to one of our nodes.
+  """
+  nodesIds: [String!]!
+
+  """A list of countries and their supported auth channels"""
+  supportedCountries: [Country!]!
+}
+
+type GraphQLApplicationError implements Error {
+  code: String
+  message: String!
+  path: [String]
+}
+
+"""Hex-encoded string of 32 bytes"""
+scalar Hex32Bytes
+
+union InitiationVia = InitiationViaIntraLedger | InitiationViaLn | InitiationViaOnChain
+
+type InitiationViaIntraLedger {
+  counterPartyUsername: Username
+  counterPartyWalletId: WalletId
+}
+
+type InitiationViaLn {
+  paymentHash: PaymentHash!
+}
+
+type InitiationViaOnChain {
+  address: OnChainAddress!
+}
+
+input IntraLedgerPaymentSendInput {
+  """Amount in satoshis."""
+  amount: SatAmount!
+
+  """Optional memo to be attached to the payment."""
+  memo: Memo
+  recipientWalletId: WalletId!
+
+  """The wallet ID of the sender."""
+  walletId: WalletId!
+}
+
+type IntraLedgerUpdate {
+  amount: SatAmount!
+  displayCurrencyPerSat: Float!
+  txNotificationType: TxNotificationType!
+  usdPerSat: Float! @deprecated(reason: "updated over displayCurrencyPerSat")
+  walletId: WalletId!
+}
+
+input IntraLedgerUsdPaymentSendInput {
+  """Amount in cents."""
+  amount: CentAmount!
+
+  """Optional memo to be attached to the payment."""
+  memo: Memo
+  recipientWalletId: WalletId!
+
+  """The wallet ID of the sender."""
+  walletId: WalletId!
+}
+
+enum InvoicePaymentStatus {
+  EXPIRED
+  PAID
+  PENDING
+}
+
+scalar Language
+
+type LnInvoice {
+  paymentHash: PaymentHash!
+  paymentRequest: LnPaymentRequest!
+  paymentSecret: LnPaymentSecret!
+  satoshis: SatAmount
+}
+
+input LnInvoiceCreateInput {
+  """Amount in satoshis."""
+  amount: SatAmount!
+
+  """Optional invoice expiration time in minutes."""
+  expiresIn: Minutes
+
+  """Optional memo for the lightning invoice."""
+  memo: Memo
+
+  """Wallet ID for a BTC wallet belonging to the current account."""
+  walletId: WalletId!
+}
+
+input LnInvoiceCreateOnBehalfOfRecipientInput {
+  """Amount in satoshis."""
+  amount: SatAmount!
+  descriptionHash: Hex32Bytes
+
+  """Optional invoice expiration time in minutes."""
+  expiresIn: Minutes
+
+  """Optional memo for the lightning invoice."""
+  memo: Memo
+
+  """Wallet ID for a BTC wallet which belongs to any account."""
+  recipientWalletId: WalletId!
+}
+
+input LnInvoiceFeeProbeInput {
+  paymentRequest: LnPaymentRequest!
+  walletId: WalletId!
 }
 
 type LnInvoicePayload {
@@ -893,38 +418,64 @@ type LnInvoicePayload {
   invoice: LnInvoice
 }
 
-type LnInvoice {
+input LnInvoicePaymentInput {
+  """Optional memo to associate with the lightning invoice."""
+  memo: Memo
+
+  """Payment request representing the invoice which is being paid."""
   paymentRequest: LnPaymentRequest!
+
+  """
+  Wallet ID with sufficient balance to cover amount of invoice.  Must belong to the account of the current user.
+  """
+  walletId: WalletId!
+}
+
+input LnInvoicePaymentStatusInput {
+  paymentRequest: LnPaymentRequest!
+}
+
+type LnInvoicePaymentStatusPayload {
+  errors: [Error!]!
+  status: InvoicePaymentStatus
+}
+
+type LnNoAmountInvoice {
   paymentHash: PaymentHash!
+  paymentRequest: LnPaymentRequest!
   paymentSecret: LnPaymentSecret!
-  satoshis: SatAmount
 }
 
-input LnInvoiceCreateOnBehalfOfRecipientInput {
-  # Wallet ID for a BTC wallet which belongs to any account.
-  recipientWalletId: WalletId!
+input LnNoAmountInvoiceCreateInput {
+  """Optional invoice expiration time in minutes."""
+  expiresIn: Minutes
 
-  # Amount in satoshis.
+  """Optional memo for the lightning invoice."""
+  memo: Memo
+
+  """
+  ID for either a USD or BTC wallet belonging to the account of the current user.
+  """
+  walletId: WalletId!
+}
+
+input LnNoAmountInvoiceCreateOnBehalfOfRecipientInput {
+  """Optional invoice expiration time in minutes."""
+  expiresIn: Minutes
+
+  """Optional memo for the lightning invoice."""
+  memo: Memo
+
+  """
+  ID for either a USD or BTC wallet which belongs to the account of any user.
+  """
+  recipientWalletId: WalletId!
+}
+
+input LnNoAmountInvoiceFeeProbeInput {
   amount: SatAmount!
-
-  # Optional memo for the lightning invoice.
-  memo: Memo
-  descriptionHash: Hex32Bytes
-}
-
-# Hex-encoded string of 32 bytes
-scalar Hex32Bytes
-
-input LnUsdInvoiceCreateOnBehalfOfRecipientInput {
-  # Wallet ID for a USD wallet which belongs to the account of any user.
-  recipientWalletId: WalletId!
-
-  # Amount in USD cents.
-  amount: CentAmount!
-
-  # Optional memo for the lightning invoice. Acts as a note to the recipient.
-  memo: Memo
-  descriptionHash: Hex32Bytes
+  paymentRequest: LnPaymentRequest!
+  walletId: WalletId!
 }
 
 type LnNoAmountInvoicePayload {
@@ -932,245 +483,247 @@ type LnNoAmountInvoicePayload {
   invoice: LnNoAmountInvoice
 }
 
-type LnNoAmountInvoice {
-  paymentRequest: LnPaymentRequest!
-  paymentHash: PaymentHash!
-  paymentSecret: LnPaymentSecret!
-}
-
-input LnNoAmountInvoiceCreateOnBehalfOfRecipientInput {
-  # ID for either a USD or BTC wallet which belongs to the account of any user.
-  recipientWalletId: WalletId!
-
-  # Optional memo for the lightning invoice.
-  memo: Memo
-}
-
-type UpgradePayload {
-  errors: [Error!]!
-  success: Boolean!
-  authToken: AuthToken
-}
-
-input UserLoginUpgradeInput {
-  phone: Phone!
-  code: OneTimeAuthCode!
-}
-
-type UserQuizQuestionUpdateCompletedPayload {
-  errors: [Error!]!
-  userQuizQuestion: UserQuizQuestion
-}
-
-input UserQuizQuestionUpdateCompletedInput {
-  id: ID!
-}
-
-type QuizCompletedPayload {
-  errors: [Error!]!
-  quiz: Quiz
-}
-
-input QuizCompletedInput {
-  id: ID!
-}
-
-input DeviceNotificationTokenCreateInput {
-  deviceToken: String!
-}
-
-type UserUpdateLanguagePayload {
-  errors: [Error!]!
-  user: User
-}
-
-input UserUpdateLanguageInput {
-  language: Language!
-}
-
-type UserUpdateUsernamePayload {
-  errors: [Error!]!
-  user: User
-}
-
-input UserUpdateUsernameInput {
-  username: Username!
-}
-
-type UserContactUpdateAliasPayload {
-  errors: [Error!]!
-  contact: UserContact
-}
-
-input UserContactUpdateAliasInput {
-  username: Username!
-  alias: ContactAlias!
-}
-
-type AccountUpdateDefaultWalletIdPayload {
-  errors: [Error!]!
-  account: ConsumerAccount
-}
-
-input AccountUpdateDefaultWalletIdInput {
-  walletId: WalletId!
-}
-
-type AccountUpdateDisplayCurrencyPayload {
-  errors: [Error!]!
-  account: ConsumerAccount
-}
-
-input AccountUpdateDisplayCurrencyInput {
-  currency: DisplayCurrency!
-}
-
-type AccountDeletePayload {
-  errors: [Error!]!
-  success: Boolean!
-}
-
-type PaymentSendPayload {
-  errors: [Error!]!
-  status: PaymentSendResult
-}
-
-enum PaymentSendResult {
-  SUCCESS
-  FAILURE
-  PENDING
-  ALREADY_PAID
-}
-
-input IntraLedgerPaymentSendInput {
-  # The wallet ID of the sender.
-  walletId: WalletId!
-  recipientWalletId: WalletId!
-
-  # Amount in satoshis.
+input LnNoAmountInvoicePaymentInput {
+  """Amount to pay in satoshis."""
   amount: SatAmount!
 
-  # Optional memo to be attached to the payment.
+  """Optional memo to associate with the lightning invoice."""
   memo: Memo
-}
 
-input IntraLedgerUsdPaymentSendInput {
-  # The wallet ID of the sender.
-  walletId: WalletId!
-  recipientWalletId: WalletId!
-
-  # Amount in cents.
-  amount: CentAmount!
-
-  # Optional memo to be attached to the payment.
-  memo: Memo
-}
-
-type SatAmountPayload {
-  errors: [Error!]!
-  amount: SatAmount
-}
-
-input LnInvoiceFeeProbeInput {
-  walletId: WalletId!
+  """Payment request representing the invoice which is being paid."""
   paymentRequest: LnPaymentRequest!
-}
 
-input LnUsdInvoiceFeeProbeInput {
+  """
+  Wallet ID with sufficient balance to cover amount defined in mutation request.  Must belong to the account of the current user.
+  """
   walletId: WalletId!
-  paymentRequest: LnPaymentRequest!
-}
-
-input LnNoAmountInvoiceFeeProbeInput {
-  walletId: WalletId!
-  paymentRequest: LnPaymentRequest!
-  amount: SatAmount!
-}
-
-type CentAmountPayload {
-  errors: [Error!]!
-  amount: CentAmount
 }
 
 input LnNoAmountUsdInvoiceFeeProbeInput {
-  walletId: WalletId!
-  paymentRequest: LnPaymentRequest!
   amount: CentAmount!
-}
-
-input LnInvoiceCreateInput {
-  # Wallet ID for a BTC wallet belonging to the current account.
-  walletId: WalletId!
-
-  # Amount in satoshis.
-  amount: SatAmount!
-
-  # Optional memo for the lightning invoice.
-  memo: Memo
-}
-
-input LnUsdInvoiceCreateInput {
-  # Wallet ID for a USD wallet belonging to the current user.
-  walletId: WalletId!
-
-  # Amount in USD cents.
-  amount: CentAmount!
-
-  # Optional memo for the lightning invoice.
-  memo: Memo
-}
-
-input LnNoAmountInvoiceCreateInput {
-  # ID for either a USD or BTC wallet belonging to the account of the current user.
-  walletId: WalletId!
-
-  # Optional memo for the lightning invoice.
-  memo: Memo
-}
-
-input LnInvoicePaymentInput {
-  # Wallet ID with sufficient balance to cover amount of invoice.  Must belong to the account of the current user.
-  walletId: WalletId!
-
-  # Payment request representing the invoice which is being paid.
   paymentRequest: LnPaymentRequest!
-
-  # Optional memo to associate with the lightning invoice.
-  memo: Memo
-}
-
-input LnNoAmountInvoicePaymentInput {
-  # Wallet ID with sufficient balance to cover amount defined in mutation request.  Must belong to the account of the current user.
   walletId: WalletId!
-
-  # Payment request representing the invoice which is being paid.
-  paymentRequest: LnPaymentRequest!
-
-  # Amount to pay in satoshis.
-  amount: SatAmount!
-
-  # Optional memo to associate with the lightning invoice.
-  memo: Memo
 }
 
 input LnNoAmountUsdInvoicePaymentInput {
-  # Wallet ID with sufficient balance to cover amount defined in mutation request.  Must belong to the account of the current user.
-  walletId: WalletId!
-
-  # Payment request representing the invoice which is being paid.
-  paymentRequest: LnPaymentRequest!
-
-  # Amount to pay in USD cents.
+  """Amount to pay in USD cents."""
   amount: CentAmount!
 
-  # Optional memo to associate with the lightning invoice.
+  """Optional memo to associate with the lightning invoice."""
   memo: Memo
+
+  """Payment request representing the invoice which is being paid."""
+  paymentRequest: LnPaymentRequest!
+
+  """
+  Wallet ID with sufficient balance to cover amount defined in mutation request.  Must belong to the account of the current user.
+  """
+  walletId: WalletId!
 }
 
-type OnChainAddressPayload {
-  errors: [Error!]!
-  address: OnChainAddress
+scalar LnPaymentPreImage
+
+"""BOLT11 lightning invoice payment request with the amount included"""
+scalar LnPaymentRequest
+
+scalar LnPaymentSecret
+
+type LnUpdate {
+  paymentHash: PaymentHash!
+  status: InvoicePaymentStatus!
+  walletId: WalletId!
 }
+
+input LnUsdInvoiceCreateInput {
+  """Amount in USD cents."""
+  amount: CentAmount!
+
+  """Optional invoice expiration time in minutes."""
+  expiresIn: Minutes
+
+  """Optional memo for the lightning invoice."""
+  memo: Memo
+
+  """Wallet ID for a USD wallet belonging to the current user."""
+  walletId: WalletId!
+}
+
+input LnUsdInvoiceCreateOnBehalfOfRecipientInput {
+  """Amount in USD cents."""
+  amount: CentAmount!
+  descriptionHash: Hex32Bytes
+
+  """Optional invoice expiration time in minutes."""
+  expiresIn: Minutes
+
+  """
+  Optional memo for the lightning invoice. Acts as a note to the recipient.
+  """
+  memo: Memo
+
+  """Wallet ID for a USD wallet which belongs to the account of any user."""
+  recipientWalletId: WalletId!
+}
+
+input LnUsdInvoiceFeeProbeInput {
+  paymentRequest: LnPaymentRequest!
+  walletId: WalletId!
+}
+
+type MapInfo {
+  coordinates: Coordinates!
+  title: String!
+}
+
+type MapMarker {
+  mapInfo: MapInfo!
+  username: Username
+}
+
+"""Text field in a lightning payment transaction"""
+scalar Memo
+
+"""(Positive) amount of minutes"""
+scalar Minutes
+
+type MobileVersions {
+  currentSupported: Int!
+  minSupported: Int!
+  platform: String!
+}
+
+type Mutation {
+  accountDelete: AccountDeletePayload!
+  accountUpdateDefaultWalletId(input: AccountUpdateDefaultWalletIdInput!): AccountUpdateDefaultWalletIdPayload!
+  accountUpdateDisplayCurrency(input: AccountUpdateDisplayCurrencyInput!): AccountUpdateDisplayCurrencyPayload!
+  captchaCreateChallenge: CaptchaCreateChallengePayload!
+  captchaRequestAuthCode(input: CaptchaRequestAuthCodeInput!): SuccessPayload!
+  deviceNotificationTokenCreate(input: DeviceNotificationTokenCreateInput!): SuccessPayload!
+  feedbackSubmit(input: FeedbackSubmitInput!): SuccessPayload!
+
+  """
+  Actions a payment which is internal to the ledger e.g. it does
+  not use onchain/lightning. Returns payment status (success,
+  failed, pending, already_paid).
+  """
+  intraLedgerPaymentSend(input: IntraLedgerPaymentSendInput!): PaymentSendPayload!
+
+  """
+  Actions a payment which is internal to the ledger e.g. it does
+  not use onchain/lightning. Returns payment status (success,
+  failed, pending, already_paid).
+  """
+  intraLedgerUsdPaymentSend(input: IntraLedgerUsdPaymentSendInput!): PaymentSendPayload!
+
+  """
+  Returns a lightning invoice for an associated wallet.
+  When invoice is paid the value will be credited to a BTC wallet.
+  Expires after 'expiresIn' or 24 hours.
+  """
+  lnInvoiceCreate(input: LnInvoiceCreateInput!): LnInvoicePayload!
+
+  """
+  Returns a lightning invoice for an associated wallet.
+  When invoice is paid the value will be credited to a BTC wallet.
+  Expires after 'expiresIn' or 24 hours.
+  """
+  lnInvoiceCreateOnBehalfOfRecipient(input: LnInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
+  lnInvoiceFeeProbe(input: LnInvoiceFeeProbeInput!): SatAmountPayload!
+
+  """
+  Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
+  Provided wallet can be USD or BTC and must have sufficient balance to cover amount in lightning invoice.
+  Returns payment status (success, failed, pending, already_paid).
+  """
+  lnInvoicePaymentSend(input: LnInvoicePaymentInput!): PaymentSendPayload!
+
+  """
+  Returns a lightning invoice for an associated wallet.
+  Can be used to receive any supported currency value (currently USD or BTC).
+  Expires after 'expiresIn' or 24 hours for BTC invoices or 5 minutes for USD invoices.
+  """
+  lnNoAmountInvoiceCreate(input: LnNoAmountInvoiceCreateInput!): LnNoAmountInvoicePayload!
+
+  """
+  Returns a lightning invoice for an associated wallet.
+  Can be used to receive any supported currency value (currently USD or BTC).
+  Expires after 'expiresIn' or 24 hours for BTC invoices or 5 minutes for USD invoices.
+  """
+  lnNoAmountInvoiceCreateOnBehalfOfRecipient(input: LnNoAmountInvoiceCreateOnBehalfOfRecipientInput!): LnNoAmountInvoicePayload!
+  lnNoAmountInvoiceFeeProbe(input: LnNoAmountInvoiceFeeProbeInput!): SatAmountPayload!
+
+  """
+  Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
+  Provided wallet must be BTC and must have sufficient balance to cover amount specified in mutation request.
+  Returns payment status (success, failed, pending, already_paid).
+  """
+  lnNoAmountInvoicePaymentSend(input: LnNoAmountInvoicePaymentInput!): PaymentSendPayload!
+  lnNoAmountUsdInvoiceFeeProbe(input: LnNoAmountUsdInvoiceFeeProbeInput!): CentAmountPayload!
+
+  """
+  Pay a lightning invoice using a balance from a wallet which is owned by the account of the current user.
+  Provided wallet must be USD and have sufficient balance to cover amount specified in mutation request.
+  Returns payment status (success, failed, pending, already_paid).
+  """
+  lnNoAmountUsdInvoicePaymentSend(input: LnNoAmountUsdInvoicePaymentInput!): PaymentSendPayload!
+
+  """
+  Returns a lightning invoice denominated in satoshis for an associated wallet.
+  When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.
+  Expires after 'expiresIn' or 5 minutes (short expiry time because there is a USD/BTC exchange rate
+  associated with the amount).
+  """
+  lnUsdInvoiceCreate(input: LnUsdInvoiceCreateInput!): LnInvoicePayload!
+
+  """
+  Returns a lightning invoice denominated in satoshis for an associated wallet.
+  When invoice is paid the equivalent value at invoice creation will be credited to a USD wallet.
+  Expires after 'expiresIn' or 5 minutes (short expiry time because there is a USD/BTC exchange rate
+    associated with the amount).
+  """
+  lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): SatAmountPayload!
+  onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
+  onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
+  onChainPaymentSend(input: OnChainPaymentSendInput!): PaymentSendPayload!
+  onChainPaymentSendAll(input: OnChainPaymentSendAllInput!): PaymentSendPayload!
+  onChainUsdPaymentSend(input: OnChainUsdPaymentSendInput!): PaymentSendPayload!
+  onChainUsdPaymentSendAsBtcDenominated(input: OnChainUsdPaymentSendAsBtcDenominatedInput!): PaymentSendPayload!
+  quizCompleted(input: QuizCompletedInput!): QuizCompletedPayload!
+  userContactUpdateAlias(input: UserContactUpdateAliasInput!): UserContactUpdateAliasPayload! @deprecated(reason: "will be moved to AccountContact")
+  userEmailDelete: UserEmailDeletePayload!
+  userEmailRegistrationInitiate(input: UserEmailRegistrationInitiateInput!): UserEmailRegistrationInitiatePayload!
+  userEmailRegistrationValidate(input: UserEmailRegistrationValidateInput!): UserEmailRegistrationValidatePayload!
+  userLogin(input: UserLoginInput!): AuthTokenPayload!
+  userLoginUpgrade(input: UserLoginUpgradeInput!): UpgradePayload!
+  userLogout(input: UserLogoutInput!): SuccessPayload!
+  userPhoneDelete: UserPhoneDeletePayload!
+  userPhoneRegistrationInitiate(input: UserPhoneRegistrationInitiateInput!): SuccessPayload!
+  userPhoneRegistrationValidate(input: UserPhoneRegistrationValidateInput!): UserPhoneRegistrationValidatePayload!
+  userQuizQuestionUpdateCompleted(input: UserQuizQuestionUpdateCompletedInput!): UserQuizQuestionUpdateCompletedPayload! @deprecated(reason: "Use QuizCompletedMutation instead")
+  userRequestAuthCode(input: UserRequestAuthCodeInput!): SuccessPayload!
+  userTotpDelete(input: UserTotpDeleteInput!): UserTotpDeletePayload!
+  userTotpRegistrationInitiate(input: UserTotpRegistrationInitiateInput!): UserTotpRegistrationInitiatePayload!
+  userTotpRegistrationValidate(input: UserTotpRegistrationValidateInput!): UserTotpRegistrationValidatePayload!
+  userUpdateLanguage(input: UserUpdateLanguageInput!): UserUpdateLanguagePayload!
+  userUpdateUsername(input: UserUpdateUsernameInput!): UserUpdateUsernamePayload! @deprecated(reason: "Username will be moved to @Handle in Accounts. Also SetUsername naming should be used instead of UpdateUsername to reflect the idempotency of Handles")
+}
+
+type MyUpdatesPayload {
+  errors: [Error!]!
+  me: User
+  update: UserUpdate
+}
+
+enum Network {
+  mainnet
+  regtest
+  signet
+  testnet
+}
+
+"""An address for an on-chain bitcoin destination"""
+scalar OnChainAddress
 
 input OnChainAddressCreateInput {
   walletId: WalletId!
@@ -1180,96 +733,143 @@ input OnChainAddressCurrentInput {
   walletId: WalletId!
 }
 
-input OnChainPaymentSendInput {
-  walletId: WalletId!
-  address: OnChainAddress!
-  amount: SatAmount!
-  speed: PayoutSpeed = FAST
-  memo: Memo
-}
-
-input OnChainUsdPaymentSendInput {
-  walletId: WalletId!
-  address: OnChainAddress!
-  amount: CentAmount!
-  speed: PayoutSpeed = FAST
-  memo: Memo
-}
-
-input OnChainUsdPaymentSendAsBtcDenominatedInput {
-  walletId: WalletId!
-  address: OnChainAddress!
-  amount: SatAmount!
-  speed: PayoutSpeed = FAST
-  memo: Memo
+type OnChainAddressPayload {
+  address: OnChainAddress
+  errors: [Error!]!
 }
 
 input OnChainPaymentSendAllInput {
-  walletId: WalletId!
   address: OnChainAddress!
-  speed: PayoutSpeed = FAST
   memo: Memo
-}
-
-type Subscription {
-  myUpdates: MyUpdatesPayload!
-  price(input: PriceInput!): PricePayload!
-
-  # Returns the price of 1 satoshi
-  realtimePrice(input: RealtimePriceInput!): RealtimePricePayload!
-  lnInvoicePaymentStatus(
-    input: LnInvoicePaymentStatusInput!
-  ): LnInvoicePaymentStatusPayload!
-}
-
-type MyUpdatesPayload {
-  errors: [Error!]!
-  update: UserUpdate
-  me: User
-}
-
-union UserUpdate =
-    RealtimePrice
-  | Price
-  | LnUpdate
-  | OnChainUpdate
-  | IntraLedgerUpdate
-
-type LnUpdate {
-  paymentHash: PaymentHash!
-  status: InvoicePaymentStatus!
+  speed: PayoutSpeed = FAST
+  targetConfirmations: TargetConfirmations = 0 @deprecated(reason: "Ignored - will be replaced")
   walletId: WalletId!
 }
+
+input OnChainPaymentSendInput {
+  address: OnChainAddress!
+  amount: SatAmount!
+  memo: Memo
+  speed: PayoutSpeed = FAST
+  targetConfirmations: TargetConfirmations = 0 @deprecated(reason: "Ignored - will be replaced")
+  walletId: WalletId!
+}
+
+type OnChainTxFee {
+  amount: SatAmount!
+  targetConfirmations: TargetConfirmations! @deprecated(reason: "Ignored - will be removed")
+}
+
+scalar OnChainTxHash
 
 type OnChainUpdate {
-  txNotificationType: TxNotificationType!
+  amount: SatAmount!
+  displayCurrencyPerSat: Float!
   txHash: OnChainTxHash!
-  amount: SatAmount!
-  displayCurrencyPerSat: Float!
-  usdPerSat: Float! @deprecated(reason: "updated over displayCurrencyPerSat")
-  walletId: WalletId!
-}
-
-enum TxNotificationType {
-  OnchainReceipt
-  OnchainReceiptPending
-  OnchainPayment
-  LnInvoicePaid
-  IntraLedgerReceipt
-  IntraLedgerPayment
-}
-
-type IntraLedgerUpdate {
   txNotificationType: TxNotificationType!
-  amount: SatAmount!
-  displayCurrencyPerSat: Float!
   usdPerSat: Float! @deprecated(reason: "updated over displayCurrencyPerSat")
   walletId: WalletId!
 }
 
-type PricePayload {
+input OnChainUsdPaymentSendAsBtcDenominatedInput {
+  address: OnChainAddress!
+  amount: SatAmount!
+  memo: Memo
+  speed: PayoutSpeed = FAST
+  targetConfirmations: TargetConfirmations = 0 @deprecated(reason: "Ignored - will be replaced")
+  walletId: WalletId!
+}
+
+input OnChainUsdPaymentSendInput {
+  address: OnChainAddress!
+  amount: CentAmount!
+  memo: Memo
+  speed: PayoutSpeed = FAST
+  targetConfirmations: TargetConfirmations = 0 @deprecated(reason: "Ignored - will be replaced")
+  walletId: WalletId!
+}
+
+type OnChainUsdTxFee {
+  amount: CentAmount!
+  targetConfirmations: TargetConfirmations! @deprecated(reason: "Ignored - will be removed")
+}
+
+type OneDayAccountLimit implements AccountLimit {
+  """
+  The rolling time interval value in seconds for the current 24 hour period.
+  """
+  interval: Seconds
+
+  """
+  The amount of cents remaining below the limit for the current 24 hour period.
+  """
+  remainingLimit: CentAmount
+
+  """The current maximum limit for a given 24 hour period."""
+  totalLimit: CentAmount!
+}
+
+"""An authentication code valid for a single use"""
+scalar OneTimeAuthCode
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+}
+
+scalar PaymentHash
+
+type PaymentSendPayload {
   errors: [Error!]!
-  price: Price
+  status: PaymentSendResult
+}
+
+enum PaymentSendResult {
+  ALREADY_PAID
+  FAILURE
+  PENDING
+  SUCCESS
+}
+
+enum PayoutSpeed {
+  FAST
+}
+
+"""Phone number which includes country code"""
+scalar Phone
+
+enum PhoneCodeChannelType {
+  SMS
+  WHATSAPP
+}
+
+"""
+Price amount expressed in base/offset. To calculate, use: `base / 10^offset`
+"""
+type Price {
+  base: SafeInt!
+  currencyUnit: String!
+  formattedAmount: String!
+  offset: Int!
+}
+
+"""The range for the X axis in the BTC price graph"""
+enum PriceGraphRange {
+  FIVE_YEARS
+  ONE_DAY
+  ONE_MONTH
+  ONE_WEEK
+  ONE_YEAR
 }
 
 input PriceInput {
@@ -1278,9 +878,117 @@ input PriceInput {
   priceCurrencyUnit: ExchangeCurrencyUnit!
 }
 
-enum ExchangeCurrencyUnit {
-  BTCSAT
-  USDCENT
+interface PriceInterface {
+  base: SafeInt!
+  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
+  offset: Int!
+}
+
+"""Price of 1 sat in base/offset. To calculate, use: `base / 10^offset`"""
+type PriceOfOneSatInMinorUnit implements PriceInterface {
+  base: SafeInt!
+  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
+  offset: Int!
+}
+
+"""
+Price of 1 sat or 1 usd cent in base/offset. To calculate, use: `base / 10^offset`
+"""
+type PriceOfOneSettlementMinorUnitInDisplayMinorUnit implements PriceInterface {
+  base: SafeInt!
+  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
+  formattedAmount: String! @deprecated(reason: "Deprecated please use `base / 10^offset`")
+  offset: Int!
+}
+
+"""
+Price of 1 usd cent in base/offset. To calculate, use: `base / 10^offset`
+"""
+type PriceOfOneUsdCentInMinorUnit implements PriceInterface {
+  base: SafeInt!
+  currencyUnit: String! @deprecated(reason: "Deprecated due to type renaming")
+  offset: Int!
+}
+
+type PricePayload {
+  errors: [Error!]!
+  price: Price
+}
+
+type PricePoint {
+  price: Price!
+
+  """
+  Unix timestamp (number of seconds elapsed since January 1, 1970 00:00:00 UTC)
+  """
+  timestamp: Timestamp!
+}
+
+"""
+A public view of a generic wallet which stores value in one of our supported currencies.
+"""
+type PublicWallet {
+  id: ID!
+  walletCurrency: WalletCurrency!
+}
+
+type Query {
+  accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet!
+  btcPrice(currency: DisplayCurrency! = "USD"): Price @deprecated(reason: "Deprecated in favor of realtimePrice")
+  btcPriceList(range: PriceGraphRange!): [PricePoint]
+  businessMapMarkers: [MapMarker]
+  currencyList: [Currency!]!
+  globals: Globals
+  lnInvoicePaymentStatus(input: LnInvoicePaymentStatusInput!): LnInvoicePaymentStatusPayload!
+  me: User
+  mobileVersions: [MobileVersions]
+  onChainTxFee(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, targetConfirmations: TargetConfirmations = 0 @deprecated(reason: "Ignored - will be replaced"), walletId: WalletId!): OnChainTxFee!
+  onChainUsdTxFee(address: OnChainAddress!, amount: CentAmount!, speed: PayoutSpeed = FAST, targetConfirmations: TargetConfirmations = 0 @deprecated(reason: "Ignored - will be replaced"), walletId: WalletId!): OnChainUsdTxFee!
+  onChainUsdTxFeeAsBtcDenominated(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, targetConfirmations: TargetConfirmations = 0 @deprecated(reason: "Ignored - will be replaced"), walletId: WalletId!): OnChainUsdTxFee!
+  quizQuestions: [QuizQuestion] @deprecated(reason: "TODO: remove. we don't need a non authenticated version of this query. the users can only do the query while authenticated")
+
+  """Returns 1 Sat and 1 Usd Cent price for the given currency"""
+  realtimePrice(currency: DisplayCurrency = "USD"): RealtimePrice!
+  userDefaultWalletId(username: Username!): WalletId! @deprecated(reason: "will be migrated to AccountDefaultWalletId")
+  usernameAvailable(username: Username!): Boolean
+}
+
+type Quiz {
+  """The reward in Satoshis for the quiz question"""
+  amount: SatAmount!
+  completed: Boolean!
+  id: ID!
+}
+
+input QuizCompletedInput {
+  id: ID!
+}
+
+type QuizCompletedPayload {
+  errors: [Error!]!
+  quiz: Quiz
+}
+
+type QuizQuestion {
+  """The earn reward in Satoshis for the quiz question"""
+  earnAmount: SatAmount!
+  id: ID!
+}
+
+type RealtimePrice {
+  btcSatPrice: PriceOfOneSatInMinorUnit!
+  denominatorCurrency: DisplayCurrency!
+  id: ID!
+
+  """
+  Unix timestamp (number of seconds elapsed since January 1, 1970 00:00:00 UTC)
+  """
+  timestamp: Timestamp!
+  usdCentPrice: PriceOfOneUsdCentInMinorUnit!
+}
+
+input RealtimePriceInput {
+  currency: DisplayCurrency = "USD"
 }
 
 type RealtimePricePayload {
@@ -1288,6 +996,464 @@ type RealtimePricePayload {
   realtimePrice: RealtimePrice
 }
 
-input RealtimePriceInput {
-  currency: DisplayCurrency = "USD"
+"""
+Non-fractional signed whole numeric value between -(2^53) + 1 and 2^53 - 1
+"""
+scalar SafeInt
+
+"""(Positive) Satoshi amount"""
+scalar SatAmount
+
+type SatAmountPayload {
+  amount: SatAmount
+  errors: [Error!]!
 }
+
+"""(Positive) amount of seconds"""
+scalar Seconds
+
+union SettlementVia = SettlementViaIntraLedger | SettlementViaLn | SettlementViaOnChain
+
+type SettlementViaIntraLedger {
+  """
+  Settlement destination: Could be null if the payee does not have a username
+  """
+  counterPartyUsername: Username
+  counterPartyWalletId: WalletId
+}
+
+type SettlementViaLn {
+  paymentSecret: LnPaymentSecret @deprecated(reason: "Shifting property to 'preImage' to improve granularity of the LnPaymentSecret type")
+  preImage: LnPaymentPreImage
+}
+
+type SettlementViaOnChain {
+  transactionHash: OnChainTxHash
+  vout: Int
+}
+
+"""An amount (of a currency) that can be negative (e.g. in a transaction)"""
+scalar SignedAmount
+
+"""
+A string amount (of a currency) that can be negative (e.g. in a transaction)
+"""
+scalar SignedDisplayMajorAmount
+
+type Subscription {
+  lnInvoicePaymentStatus(input: LnInvoicePaymentStatusInput!): LnInvoicePaymentStatusPayload!
+  myUpdates: MyUpdatesPayload!
+  price(input: PriceInput!): PricePayload!
+
+  """Returns the price of 1 satoshi"""
+  realtimePrice(input: RealtimePriceInput!): RealtimePricePayload!
+}
+
+type SuccessPayload {
+  errors: [Error!]!
+  success: Boolean
+}
+
+"""
+(Positive) Number of blocks in which the transaction is expected to be confirmed
+"""
+scalar TargetConfirmations
+
+"""
+Timestamp field, serialized as Unix time (the number of seconds since the Unix epoch)
+"""
+scalar Timestamp
+
+"""A time-based one-time password"""
+scalar TotpCode
+
+"""An id to be passed between set and verify for confirming totp"""
+scalar TotpRegistrationId
+
+"""A secret to generate time-based one-time password"""
+scalar TotpSecret
+
+"""
+Give details about an individual transaction.
+Galoy have a smart routing system which is automatically
+settling intraledger when both the payer and payee use the same wallet
+therefore it's possible the transactions is being initiated onchain
+or with lightning but settled intraledger.
+"""
+type Transaction {
+  createdAt: Timestamp!
+  direction: TxDirection!
+  id: ID!
+
+  """From which protocol the payment has been initiated."""
+  initiationVia: InitiationVia!
+  memo: Memo
+
+  """Amount of the settlement currency sent or received."""
+  settlementAmount: SignedAmount!
+
+  """Wallet currency for transaction."""
+  settlementCurrency: WalletCurrency!
+  settlementDisplayAmount: SignedDisplayMajorAmount!
+  settlementDisplayCurrency: DisplayCurrency!
+  settlementDisplayFee: SignedDisplayMajorAmount!
+  settlementFee: SignedAmount!
+
+  """Price in WALLETCURRENCY/SETTLEMENTUNIT at time of settlement."""
+  settlementPrice: PriceOfOneSettlementMinorUnitInDisplayMinorUnit!
+
+  """To which protocol the payment has settled on."""
+  settlementVia: SettlementVia!
+  status: TxStatus!
+}
+
+"""A connection to a list of items."""
+type TransactionConnection {
+  """A list of edges."""
+  edges: [TransactionEdge!]
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+}
+
+"""An edge in a connection."""
+type TransactionEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: Transaction!
+}
+
+enum TxDirection {
+  RECEIVE
+  SEND
+}
+
+enum TxNotificationType {
+  IntraLedgerPayment
+  IntraLedgerReceipt
+  LnInvoicePaid
+  OnchainPayment
+  OnchainReceipt
+  OnchainReceiptPending
+}
+
+enum TxStatus {
+  FAILURE
+  PENDING
+  SUCCESS
+}
+
+type UpgradePayload {
+  authToken: AuthToken
+  errors: [Error!]!
+  success: Boolean!
+}
+
+"""
+A wallet belonging to an account which contains a USD balance and a list of transactions.
+"""
+type UsdWallet implements Wallet {
+  accountId: ID!
+  balance: SignedAmount!
+  id: ID!
+
+  """An unconfirmed incoming onchain balance."""
+  pendingIncomingBalance: SignedAmount!
+  transactions(
+    """Returns the items in the list that come after the specified cursor."""
+    after: String
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String
+
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
+    last: Int
+  ): TransactionConnection
+  transactionsByAddress(
+    """Returns the items that include this address."""
+    address: OnChainAddress!
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String
+
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
+    last: Int
+  ): TransactionConnection
+  walletCurrency: WalletCurrency!
+}
+
+type User {
+  """
+  Get single contact details.
+  Can include the transactions associated with the contact.
+  """
+  contactByUsername(username: Username!): UserContact! @deprecated(reason: "will be moved to Accounts")
+
+  """
+  Get full list of contacts.
+  Can include the transactions associated with each contact.
+  """
+  contacts: [UserContact!]! @deprecated(reason: "will be moved to account")
+  createdAt: Timestamp!
+  defaultAccount: Account!
+
+  """Email address"""
+  email: Email
+  id: ID!
+
+  """
+  Preferred language for user.
+  When value is 'default' the intent is to use preferred language from OS settings.
+  """
+  language: Language!
+
+  """Phone number with international calling code."""
+  phone: Phone
+
+  """List the quiz questions the user may have completed."""
+  quizQuestions: [UserQuizQuestion!]! @deprecated(reason: "use Quiz from Account instead")
+
+  """Whether TOTP is enabled for this user."""
+  totpEnabled: Boolean!
+
+  """Optional immutable user friendly identifier."""
+  username: Username @deprecated(reason: "will be moved to @Handle in Account and Wallet")
+}
+
+type UserContact {
+  """
+  Alias the user can set for this contact.
+  Only the user can see the alias attached to their contact.
+  """
+  alias: ContactAlias
+  id: Username!
+
+  """Paginated list of transactions sent to/from this contact."""
+  transactions(
+    """Returns the items in the list that come after the specified cursor."""
+    after: String
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String
+
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
+    last: Int
+  ): TransactionConnection
+  transactionsCount: Int!
+
+  """Actual identifier of the contact."""
+  username: Username!
+}
+
+input UserContactUpdateAliasInput {
+  alias: ContactAlias!
+  username: Username!
+}
+
+type UserContactUpdateAliasPayload {
+  contact: UserContact
+  errors: [Error!]!
+}
+
+type UserEmailDeletePayload {
+  errors: [Error!]!
+  me: User
+}
+
+input UserEmailRegistrationInitiateInput {
+  email: EmailAddress!
+}
+
+type UserEmailRegistrationInitiatePayload {
+  emailRegistrationId: EmailRegistrationId
+  errors: [Error!]!
+  me: User
+}
+
+input UserEmailRegistrationValidateInput {
+  code: OneTimeAuthCode!
+  emailRegistrationId: EmailRegistrationId!
+}
+
+type UserEmailRegistrationValidatePayload {
+  errors: [Error!]!
+  me: User
+}
+
+input UserLoginInput {
+  code: OneTimeAuthCode!
+  phone: Phone!
+}
+
+input UserLoginUpgradeInput {
+  code: OneTimeAuthCode!
+  phone: Phone!
+}
+
+input UserLogoutInput {
+  authToken: AuthToken!
+}
+
+"""Unique identifier of a user"""
+scalar Username
+
+type UserPhoneDeletePayload {
+  errors: [Error!]!
+  me: User
+}
+
+input UserPhoneRegistrationInitiateInput {
+  channel: PhoneCodeChannelType
+  phone: Phone!
+}
+
+input UserPhoneRegistrationValidateInput {
+  code: OneTimeAuthCode!
+  phone: Phone!
+}
+
+type UserPhoneRegistrationValidatePayload {
+  errors: [Error!]!
+  me: User
+}
+
+type UserQuizQuestion {
+  completed: Boolean!
+  question: QuizQuestion!
+}
+
+input UserQuizQuestionUpdateCompletedInput {
+  id: ID!
+}
+
+type UserQuizQuestionUpdateCompletedPayload {
+  errors: [Error!]!
+  userQuizQuestion: UserQuizQuestion
+}
+
+input UserRequestAuthCodeInput {
+  channel: PhoneCodeChannelType
+  phone: Phone!
+}
+
+input UserTotpDeleteInput {
+  authToken: AuthToken!
+}
+
+type UserTotpDeletePayload {
+  errors: [Error!]!
+  me: User
+}
+
+input UserTotpRegistrationInitiateInput {
+  authToken: AuthToken!
+}
+
+type UserTotpRegistrationInitiatePayload {
+  errors: [Error!]!
+  totpRegistrationId: TotpRegistrationId
+  totpSecret: TotpSecret
+}
+
+input UserTotpRegistrationValidateInput {
+  authToken: AuthToken!
+  totpCode: TotpCode!
+  totpRegistrationId: TotpRegistrationId!
+}
+
+type UserTotpRegistrationValidatePayload {
+  errors: [Error!]!
+  me: User
+}
+
+union UserUpdate = IntraLedgerUpdate | LnUpdate | OnChainUpdate | Price | RealtimePrice
+
+input UserUpdateLanguageInput {
+  language: Language!
+}
+
+type UserUpdateLanguagePayload {
+  errors: [Error!]!
+  user: User
+}
+
+input UserUpdateUsernameInput {
+  username: Username!
+}
+
+type UserUpdateUsernamePayload {
+  errors: [Error!]!
+  user: User
+}
+
+"""
+A generic wallet which stores value in one of our supported currencies.
+"""
+interface Wallet {
+  accountId: ID!
+  balance: SignedAmount!
+  id: ID!
+  pendingIncomingBalance: SignedAmount!
+
+  """
+  Transactions are ordered anti-chronologically,
+  ie: the newest transaction will be first
+  """
+  transactions(
+    """Returns the items in the list that come after the specified cursor."""
+    after: String
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String
+
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
+    last: Int
+  ): TransactionConnection
+
+  """
+  Transactions are ordered anti-chronologically,
+  ie: the newest transaction will be first
+  """
+  transactionsByAddress(
+    """Returns the items that include this address."""
+    address: OnChainAddress!
+
+    """Returns the items in the list that come after the specified cursor."""
+    after: String
+
+    """Returns the items in the list that come before the specified cursor."""
+    before: String
+
+    """Returns the first n items from the list."""
+    first: Int
+
+    """Returns the last n items from the list."""
+    last: Int
+  ): TransactionConnection
+  walletCurrency: WalletCurrency!
+}
+
+enum WalletCurrency {
+  BTC
+  USD
+}
+
+"""Unique identifier of a wallet"""
+scalar WalletId

--- a/src/client/queries.rs
+++ b/src/client/queries.rs
@@ -13,6 +13,14 @@ type SatAmount = Decimal;
 type CentAmount = Decimal;
 type Memo = String;
 type OnChainAddress = String;
+type PaymentHash = String;
+type LnPaymentSecret = String;
+type LnPaymentPreImage = String;
+type OnChainTxHash = String;
+type SignedDisplayMajorAmount = String;
+type DisplayCurrency = String;
+type SafeInt = Decimal;
+type Timestamp = Decimal;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -100,6 +108,15 @@ pub use self::captcha_request_auth_code::CaptchaRequestAuthCodeInput;
 )]
 pub struct QueryMe;
 pub use self::query_me::QueryMeMe;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/client/gql/schema.gql",
+    query_path = "src/client/gql/queries/transactions.gql",
+    response_derives = "Debug, Serialize, PartialEq"
+)]
+pub(super) struct Transactions;
+pub use self::transactions::TransactionsMeDefaultAccountTransactionsEdges;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/src/client/requests/me.rs
+++ b/src/client/requests/me.rs
@@ -23,26 +23,20 @@ impl GaloyClient {
 
     pub async fn list_transactions(
         &self,
-        after: Option<String>,
-        before: Option<String>,
-        last: Option<i64>,
-        first: Option<i64>,
-        wallet_ids: Option<Vec<Option<String>>>,
+        //TODO: Add pagination from BE
+
+        // after: Option<String>,
+        // before: Option<String>,
+        // last: Option<i64>,
+        // first: Option<i64>,
+        // wallet_ids: Option<Vec<Option<String>>>,
     ) -> Result<Option<Vec<TransactionsMeDefaultAccountTransactionsEdges>>, ClientError> {
-        let variables = transactions::Variables {
-            after,
-            before,
-            first,
-            last,
-            wallet_ids,
-        };
+        let variables = transactions::Variables;
 
         let response_body =
             post_graphql::<Transactions, _>(&self.graphql_client, &self.api, variables)
                 .await
                 .map_err(|err| ApiError::IssueGettingResponse(anyhow::Error::new(err)))?;
-
-        println!("{:?}", response_body);
 
         let response_data = response_body.data.ok_or(ApiError::IssueParsingResponse)?;
         let transactions = response_data
@@ -50,7 +44,7 @@ impl GaloyClient {
             .ok_or(MeError::FailedToUnwrapMe)?
             .default_account
             .transactions
-            .ok_or(ApiError::IssueParsingResponse)? //change this error
+            .ok_or(MeError::FailedToUnwrapTransactions)?
             .edges;
         Ok(transactions)
     }


### PR DESCRIPTION
This PR introduces the `transactions` command, which allows users to retrieve transaction details.

```bash
Usage: galoy-cli transactions [OPTIONS]

Options:
-l, --last <LAST>
-f, --first <FIRST>

```
The `first` option displays the first specified number of transactions for the logged-in user, and the `last` option does the same for the last specified number of transactions. If neither `first` nor `last` option is provided, the command lists all transactions for the user.

Note that pagination is currently not handled by the gql query to the backend; instead, it is being managed at the app layer. The app filters through all the transactions based on the given input. Once the query has been fixed, the pagination will be handled on the backend, and additional options named `before`, `after`, and `wallet-ids` will be added. 