### PR TITLE
Deauthorize Token on Logout

### DIFF
--- a/src/client/gql/mutations/user_logout.gql
+++ b/src/client/gql/mutations/user_logout.gql
@@ -1,0 +1,8 @@
+mutation UserLogout($input: UserLogoutInput!) {
+  userLogout(input: $input) {
+    errors {
+      __typename
+      message
+    }
+  }
+}

--- a/src/client/queries.rs
+++ b/src/client/queries.rs
@@ -36,6 +36,15 @@ pub use self::user_login::UserLoginUserLogin;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/client/gql/schema.gql",
+    query_path = "src/client/gql/mutations/user_logout.gql",
+    response_derives = "Debug, Serialize"
+)]
+pub(super) struct UserLogout;
+pub use self::user_logout::UserLogoutInput;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/client/gql/schema.gql",
     query_path = "src/client/gql/mutations/request_auth_code.gql",
     response_derives = "Debug, Serialize"
 )]


### PR DESCRIPTION
Previously, our user logout process merely involved removing the `GALOY_TOKEN` from the user's home directory (`~/.galoy-cli`). However, this approach did not fully de-authorize the authentication token. 
In this PR, we introduce an additional layer of security by incorporating the recently introduced `UserLogout` mutation on the authentication token before deleting the token. This mutation ensures complete de-authorization, preventing users from reusing the same token after logout. As a result, users will now need to explicitly log in again to regain authorized access